### PR TITLE
start `/bin` directory

### DIFF
--- a/bin/cowquote
+++ b/bin/cowquote
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# quote: print (mostly) sit-com quotes to the screen for fun
+#
+# A fun utility I wrote to work on my script-writing chops. I often manually pass funny quotes
+# into cowsay to serve as "screensavers" on terminal windows or tmux panes. This way, when I switch
+# on to them, I get a fun little kick. This was a fun way to automate the process and spice things
+# up.
+
+PROGRAM_NAME="${0##*/}"
+
+usage() {
+cat << __EOF__
+usage: $PROGRAM_NAME [option]
+Options:
+    -h | --help     show this help message
+    -t | --think    use cowthink
+    -s | --say      use cowsay (default, if installed)
+    -p | --plain    use echo (default, if cowsay is not installed)
+__EOF__
+}
+
+cmd="cowsay"  # default to cowsay
+
+while [[ -n "$1" ]]; do
+    case "$1" in
+        -h | --help)    usage
+                        exit 0
+                        ;;
+        -t | --think)   cmd="cowthink"
+                        ;;
+        -s | --say)     cmd="cowsay"
+                        ;;
+        -p | --plain)   cmd="echo"
+                        ;;
+        *)              usage
+                        exit 1
+    esac
+    shift
+done
+
+source quotes_src.sh
+
+length="${#QUOTES[@]}"
+index="$((RANDOM % length))"
+selection="${QUOTES[$index]}"
+
+if [[ ! -e "$(which cowsay)" ]]; then
+    echo "cowsay is not installed, defaulting to plain-mode"
+    echo "$selection"
+    exit 0
+fi
+
+$cmd "$selection"

--- a/bin/quotes_src.sh
+++ b/bin/quotes_src.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# funny quotes: funny quotes to use in `quote` script
+
+export QUOTES=(
+    "\"I wish there was a way to know you're in the good old days before you've actually left them.\" -- Andy Bernard"
+    "\"We need to remember what's important in life: friends, waffles, work. Or waffles, friends, work. Doesn't matter, but work is third.\" -- Leslie Knope"
+    "\"I love inside jokes. I'd love to be a part of one some day\" -- Michael Scott"
+    "\"treat yo self\" -- Tom Haverford and Donna Meagle"
+    "\"When life gives you lemons, you sell some of your grandma’s jewelry and ya go clubbin.\" -- Jean-Ralphio Saperstein"
+    "\"New York's Finest just got a whole lot finer\" -- Doug Judy"
+    "\"May your hats fly as high as your dreams\" -- Michael Scott"
+    "\"Andy Bernard does not lose competitions, he wins them. Or he quits them because they are unfair\" -- Andy Bernard"
+)

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ create_symlink() {
 
 	if [ -e "$target" ] || [ -L "$target" ]; then
 		echo "Removing existing file or directory: $target"
+		# TODO: instead of rm'ing, we should save to a backup
 		rm -rf "$target"
 	fi
 	ln -s "$source" "$target"
@@ -48,6 +49,9 @@ install_ghostty() {
     echo "Installing ghostty..."
     brew install ghostty
 }
+
+# install binaries from /bin
+create_symlink "$DOTFILES/bin" "$HOME/.local/bin"
 
 # zsh
 create_symlink "$DOTFILES/zsh/zshrc" "$HOME/.zshrc"


### PR DESCRIPTION
We wrote a binary on our local machine, move it to the dotfiles directory along with some new installation logic to put all binaries from `$DOTFILES/bin` onto the machine we're installing to.

I wrote a fun script (first of many). This PR moves the script from my local machine into my dotfiles and also tells the install script to install binaries from `$DOTFILES/bin` into `$HOME/.local/bin`